### PR TITLE
ci: Add commit lint

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,0 +1,15 @@
+name: Check that the previous commit has been linted correctly
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  commit-lint:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+      - name: seferov/pr-lint-action@master
+        run: make commit-lint

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+module.exports = {extends: ['@commitlint/config-conventional']};


### PR DESCRIPTION
Adding commit lint to ensure conventional commits (see
https://www.conventionalcommits.org/en/v1.0.0/)