### PR TITLE
ci: Add commit lint

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,0 +1,15 @@
+name: Check that the previous commit has been linted correctly
+on:
+  pull_request:
+    types: [opened, editited, synchronize, reopened]
+
+jobs:
+  commit-lint:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+        with: 
+          fetch-depth: 0 
+      - name: Lint the commit
+        run: make COMMIT_LINT_VARS='--from "${{ github.event.pull_request.base.sha }}" --to "${{ github.event.pull_request.head.sha }}"' commit-lint

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ RELATIVE_DIR_DEV=./dev/
 TERRAFORM_VERSION=0.12.20
 AWSCLI_VERSION=1.17.13-alpine3.11.3
 ALPINE_VERSION=3.11.3
+COMMIT_LINT_VERSION=8.3.5
 
 ##########################
 # Variables
@@ -37,21 +38,25 @@ TERRAFORM_DOCKER_RUN_OPTIONS=-v $(CURDIR):/app \
 	-e "AWS_SECRET_ACCESS_KEY=$(AWS_SECRET_ACCESS_KEY)" \
 	-it
 TERRAFORM_DOCKER_IMAGE=hashicorp/terraform:$(TERRAFORM_VERSION)
-TERRAFORM=docker run $(TERRAFORM_DOCKER_RUN_OPTIONS) $(TERRAFORM_DOCKER_IMAGE)
-TERRAFORM_SH=docker run $(TERRAFORM_DOCKER_RUN_OPTIONS) --entrypoint sh $(TERRAFORM_DOCKER_IMAGE)
+TERRAFORM=docker run --rm $(TERRAFORM_DOCKER_RUN_OPTIONS) $(TERRAFORM_DOCKER_IMAGE)
+TERRAFORM_SH=docker run --rm $(TERRAFORM_DOCKER_RUN_OPTIONS) --entrypoint sh $(TERRAFORM_DOCKER_IMAGE)
 TERRAFORM_VARS=-var "stage=$(STAGE)" -var "domain=$(DOMAIN)" -var "region=$(REGION)"
 
-AWS_CLI=docker run \
+AWS_CLI=docker run --rm \
 	-e "AWS_ACCESS_KEY_ID=$(AWS_ACCESS_KEY_ID)" \
 	-e "AWS_SECRET_ACCESS_KEY=$(AWS_SECRET_ACCESS_KEY)" \
 	leonyork/awscli:$(AWSCLI_VERSION)
 
-ALPINE=docker run -v $(CURDIR):/app -w /app alpine:$(ALPINE_VERSION)
+ALPINE=docker run --rm -v $(CURDIR):/app -w /app alpine:$(ALPINE_VERSION)
 DOCKER_COMPOSE_E2E=docker-compose -f e2e/e2e.docker-compose.yml
 E2E=$(DOCKER_COMPOSE_E2E) -p leonyork-com-e2e
 
 DOCKER_COMPOSE_E2E_LIGHTHOUSE=docker-compose -f e2e/e2e-lighthouse.docker-compose.yml
 E2E_LIGHTHOUSE=$(DOCKER_COMPOSE_E2E_LIGHTHOUSE) -p leonyork-com-e2e-lighthouse
+
+COMMIT_LINT_DOCKER_IMAGE=gtramontina/commitlint:$(COMMIT_LINT_VERSION) 
+COMMIT_LINT_VARS=--edit
+COMMIT_LINT=docker run --rm -v $(CURDIR)/.git:/app/.git -v $(CURDIR)/commitlint.config.js:/app/commitlint.config.js -w /app $(COMMIT_LINT_DOCKER_IMAGE) $(COMMIT_LINT_VARS)
 
 ##########################
 # Terraform outputs
@@ -136,6 +141,13 @@ destroy: .terraform-plan-destroy
 # Dev targets
 # Also see dev folder
 ##########################
+
+# Lint the commits that have been made to ensure they are conventional commits
+.PHONY: commit-lint
+commit-lint:
+	docker pull --quiet $(COMMIT_LINT_DOCKER_IMAGE)
+	$(COMMIT_LINT)
+
 # Deploy the system ready for the end2end tests
 .PHONY: e2e-deploy
 e2e-deploy:

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+module.exports = {extends: ['@commitlint/config-conventional']};


### PR DESCRIPTION
Adding commit lint to ensure conventional commits (see
https://www.conventionalcommits.org/en/v1.0.0/)